### PR TITLE
Timezone error fixed

### DIFF
--- a/app/Repositories/Metric/MetricRepository.php
+++ b/app/Repositories/Metric/MetricRepository.php
@@ -54,10 +54,13 @@ class MetricRepository
      */
     public function listPointsLastHour(Metric $metric)
     {
-        $dateTime = $this->dates->make();
-        $pointKey = $dateTime->format('H:i');
         $nrOfMinutes = 61;
         $points = $this->repository->getPointsLastHour($metric, $nrOfMinutes + $metric->threshold)->pluck('value', 'key')->take(-$nrOfMinutes);
+        foreach($points as $key => $value)
+        {
+            $points[$this->dates->make($key)->format('H:i')] = $value;
+            unset($points[$key]);
+        }
 
         return $points->sortBy(function ($point, $key) {
             return $key;


### PR DESCRIPTION
Timezone error for hourly based metrics is created by me. In my last fix, I simply did the range query from the database, sort the result and return it to the UI component. This fix will update the key to Cachet timezone and return the result to the UI component.