### PR TITLE
Make metric point api to fetch the latest value

### DIFF
--- a/app/Models/Metric.php
+++ b/app/Models/Metric.php
@@ -123,7 +123,7 @@ class Metric extends Model implements HasPresenter
      */
     public function points()
     {
-        return $this->hasMany(MetricPoint::class, 'metric_id', 'id');
+        return $this->hasMany(MetricPoint::class, 'metric_id', 'id')->latest();
     }
 
     /**


### PR DESCRIPTION
Klipfolio dashboard works like a PULL based API instead of push based. So I am using Cachet API to pull out the metric points from sqlite database. In order to get the latest values, I need this change to make it work.

Cachet is going to deliver this change in v2.4 - https://github.com/CachetHQ/Cachet/commit/f98ae4d38ecfdc32ea1bd7e75ac3d4631ecc1ca0